### PR TITLE
Create a proper runtime for WASM

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ Additionally I want to write most of my rust apps with a possible wasm target: a
 
 Due to those goals, scriptit will not give you the same amount of control that you would have embedding v8 yourself and will give you worst ergonomics than just using wasm_bindgen. It is unfortunately ruled by the lowest common denominators on both apis (v8 & wasm_bindgen).
 
-⚠️⚠️⚠️ **WASM scripting uses eval** ⚠️⚠️⚠️ I intend to change it soon but for now, please be extra careful!
-
 ## Example
 
 ```rust

--- a/src/js_v8/mod.rs
+++ b/src/js_v8/mod.rs
@@ -88,14 +88,16 @@ impl ScriptingEnvironment {
             // TODO: initialize the context here with our bindings
             global_context = v8::Global::new(scope, context);
         }
-        ScriptingEnvironment {
+        let mut se = ScriptingEnvironment {
             isolate,
             global_context,
-        }
+        };
+        se.run(include_str!("./v8_bootstrap.js")).unwrap();
+        se
     }
 
-    /// Evaluates some JS in the current environment
-    pub fn eval(&mut self, source: &str) -> Result<ScriptValue, ScriptError> {
+    /// Evaluates a single JS expression
+    pub fn eval_expression(&mut self, source: &str) -> Result<ScriptValue, ScriptError> {
         let scope = &mut v8::HandleScope::with_context(&mut self.isolate, &self.global_context);
         let source = v8::String::new(scope, source).ok_or(ScriptError::CastError {
             type_from: "&str",
@@ -117,5 +119,11 @@ impl ScriptingEnvironment {
                 return Err(trycatch_scope_to_scripterror(tc_scope, false));
             }
         }
+    }
+
+    /// Runs JavaScript code
+    pub fn run(&mut self, source: &str) -> Result<(), ScriptError> {
+        self.eval_expression(source)?;
+        Ok(())
     }
 }

--- a/src/js_v8/v8_bootstrap.js
+++ b/src/js_v8/v8_bootstrap.js
@@ -1,0 +1,2 @@
+globalThis.console = undefined;
+globalThis.JSScriptingEnvironment = undefined;

--- a/src/js_wasm/wasm_bootstrap.js
+++ b/src/js_wasm/wasm_bootstrap.js
@@ -1,9 +1,58 @@
-class JSScriptingEnvironment {
-    constructor() {}
+// @ts-check
 
-    eval(s) {
-        return eval(s);
+/**
+ * @type {(string | number | symbol)[]}
+ */
+const GLOBAL_INCLUDE_LIST = ["NaN", "Math", "Date"];
+
+/**
+ * @type {ProxyHandler}
+ */
+const ISOLATION_PROXY_HANDLER = {
+    get(target, attr) {
+        if (GLOBAL_INCLUDE_LIST.includes(attr)) {
+            return globalThis[attr];
+        }
+        return target[attr];
+    },
+    has(target, attr) {
+        return attr in globalThis || attr in target;
+    },
+};
+
+class JSScriptingEnvironment {
+    constructor() {
+        /**
+         * @type {object}
+         */
+        this.sandbox = {};
+        /**
+         * @type {Proxy<object, any>}
+         */
+        this.sandboxProxy = new Proxy(this.sandbox, ISOLATION_PROXY_HANDLER);
+    }
+
+    /**
+     * @param {string} stringSrc
+     * @returns {(sandbox: Proxy<object, any>) => any}
+     */
+    compile(stringSrc) {
+        const wrappedSource = `with (globalThis) { ${stringSrc} }`;
+        /**
+         * @type {any}
+         */
+        const compiledFunction = new Function("globalThis", wrappedSource);
+        return compiledFunction;
+    }
+
+    /**
+     * @param {(sandbox: Proxy<object, any>) => any} compiledFunction
+     * @returns {any}
+     */
+    run(compiledFunction) {
+        return compiledFunction(this.sandboxProxy);
     }
 }
 
+// @ts-ignore: we extend the global
 globalThis.JSScriptingEnvironment = JSScriptingEnvironment;

--- a/src/js_wasm/wasm_bootstrap.js
+++ b/src/js_wasm/wasm_bootstrap.js
@@ -1,0 +1,9 @@
+class JSScriptingEnvironment {
+    constructor() {}
+
+    eval(s) {
+        return eval(s);
+    }
+}
+
+globalThis.JSScriptingEnvironment = JSScriptingEnvironment;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,12 @@
 //!
 //! let mut s_env = ScriptingEnvironment::new();
 //!
-//! let src = "
+//! let src = "(function() {
 //!     const greeter = 'JS';
 //!     const greeted = 'Rust';
-//!     `Hello ${greeted}! (from ${greeter}...)`
-//! ";
-//! let res = s_env.eval(src).unwrap();
+//!     return `Hello ${greeted}! (from ${greeter}...)`;
+//! })()";
+//! let res = s_env.eval_expression(src).unwrap();
 //!
 //! assert_eq!(res, ScriptValue::String("Hello Rust! (from JS...)".to_string()));
 //! ```

--- a/tests/eval.rs
+++ b/tests/eval.rs
@@ -8,16 +8,9 @@ use wasm_bindgen_test::*;
 #[wasm_bindgen_test]
 fn trigger_compile_error() {
     let mut s_env = ScriptingEnvironment::new();
-    #[cfg(not(target_arch = "wasm32"))]
-    match s_env.eval("import async return") {
+    match s_env.eval_expression("import async return") {
         Err(ScriptError::CompileError(_)) => {}
         other => panic!("Expected a ScriptError::CompileError, got {:?}", other),
-    }
-    // in wasm32 since we defer to the host, we're qalready in the runtime!
-    #[cfg(target_arch = "wasm32")]
-    match s_env.eval("import async return") {
-        Err(ScriptError::RuntimeError(_)) => {}
-        other => panic!("Expected a ScriptError::RuntimeError, got {:?}", other),
     }
 }
 
@@ -25,7 +18,7 @@ fn trigger_compile_error() {
 #[wasm_bindgen_test]
 fn trigger_runtime_error() {
     let mut s_env = ScriptingEnvironment::new();
-    match s_env.eval("unknown_variable") {
+    match s_env.eval_expression("unknown_variable") {
         Err(ScriptError::RuntimeError(_)) => {}
         other => panic!("Expected a ScriptError::RuntimeError got {:?}", other),
     }
@@ -35,9 +28,9 @@ fn trigger_runtime_error() {
 #[wasm_bindgen_test]
 fn get_boolean_value() {
     let mut s_env = ScriptingEnvironment::new();
-    let val = s_env.eval("true").unwrap();
+    let val = s_env.eval_expression("true").unwrap();
     assert_eq!(val, ScriptValue::Boolean(true));
-    let val = s_env.eval("false").unwrap();
+    let val = s_env.eval_expression("false").unwrap();
     assert_eq!(val, ScriptValue::Boolean(false));
 }
 
@@ -45,9 +38,9 @@ fn get_boolean_value() {
 #[wasm_bindgen_test]
 fn get_string_value() {
     let mut s_env = ScriptingEnvironment::new();
-    let val = s_env.eval("`hello`").unwrap();
+    let val = s_env.eval_expression("`hello`").unwrap();
     assert_eq!(val, ScriptValue::String("hello".to_string()));
-    let val = s_env.eval("`hello ${'foo'}!`").unwrap();
+    let val = s_env.eval_expression("`hello ${'foo'}!`").unwrap();
     assert_eq!(val, ScriptValue::String("hello foo!".to_string()));
 }
 
@@ -55,11 +48,11 @@ fn get_string_value() {
 #[wasm_bindgen_test]
 fn get_number_value() {
     let mut s_env = ScriptingEnvironment::new();
-    let val = s_env.eval("123").unwrap();
+    let val = s_env.eval_expression("123").unwrap();
     assert_eq!(val, ScriptValue::Number(123.0));
-    let val = s_env.eval("12 + 3 ").unwrap();
+    let val = s_env.eval_expression("12 + 3 ").unwrap();
     assert_eq!(val, ScriptValue::Number(15.0));
-    let val = s_env.eval("NaN").unwrap();
+    let val = s_env.eval_expression("NaN").unwrap();
     match val {
         ScriptValue::Number(val) => assert!(val.is_nan()),
         _ => panic!("Expected a ScriptValue::Number, got a  {:?}", val),
@@ -70,7 +63,7 @@ fn get_number_value() {
 #[wasm_bindgen_test]
 fn get_null_value() {
     let mut s_env = ScriptingEnvironment::new();
-    let val = s_env.eval("null").unwrap();
+    let val = s_env.eval_expression("null").unwrap();
     assert_eq!(val, ScriptValue::Null);
 }
 
@@ -78,6 +71,6 @@ fn get_null_value() {
 #[wasm_bindgen_test]
 fn get_undefined_value() {
     let mut s_env = ScriptingEnvironment::new();
-    let val = s_env.eval("undefined").unwrap();
+    let val = s_env.eval_expression("undefined").unwrap();
     assert_eq!(val, ScriptValue::Undefined);
 }

--- a/tests/isolation.rs
+++ b/tests/isolation.rs
@@ -1,0 +1,28 @@
+use scriptit::{core::error::ScriptError, core::value::ScriptValue, ScriptingEnvironment};
+use wasm_bindgen_test::*;
+
+#[test]
+#[wasm_bindgen_test]
+fn ensure_no_global_prototype_leakage() {
+    let mut s_env = ScriptingEnvironment::new();
+    match s_env.eval_expression("prototype") {
+        Err(ScriptError::RuntimeError(_)) => {}
+        other => panic!("Expected a ScriptError::RuntimeError got {:?}", other),
+    }
+}
+
+#[test]
+#[wasm_bindgen_test]
+fn ensure_no_console() {
+    let mut s_env = ScriptingEnvironment::new();
+    let val = s_env.eval_expression("console").unwrap();
+    assert_eq!(val, ScriptValue::Undefined);
+}
+
+#[test]
+#[wasm_bindgen_test]
+fn ensure_no_js_scripting_environment() {
+    let mut s_env = ScriptingEnvironment::new();
+    let val = s_env.eval_expression("JSScriptingEnvironment").unwrap();
+    assert_eq!(val, ScriptValue::Undefined);
+}


### PR DESCRIPTION
This introduces stronger security boundaries by executing code as functions with a membrane to the global object. This is a temporary solution: a better way to do this, if the host permits it would be to run in an iframe.

That being said this is a much better security boundary to the old eval and lets us do some setup in JavaScript.

Fixes #5 partially.